### PR TITLE
making diacritics keys configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The extension is contained in the file hoplitekb.oxt.  Download this file from t
 To build the extension from source code, clone this repository.  Run the build.sh script to build the extension.  Install hoplitekb.oxt in LibreOffice as above.
 
 ## Use:
-Use your usual Greek keyboard to type base letters.  Use this extension to add diacritics.  After typing a vowel, while holding Control (Command on Mac), press a key 1-9 to toggle on/off diacritics.  The 1-9 keys are bound to: 
+Toggle on the extension by pressing the icon installed in the toolbar. The letters a-z and A-Z will be automatically transliterated into Greek characters. To add diacritics, after typing a vowel, press a key 1-9 to toggle on/off diacritics.  The 1-9 keys, by default, are bound to: 
 1. rough breathing 
 2. smooth breathing
 3. acute
@@ -36,7 +36,7 @@ Use your usual Greek keyboard to type base letters.  Use this extension to add d
 8. iota subscript
 9. diaeresis
 
-The key bindings can be changed in the file Accelerators.xcu.  Then rebuild the extension and reinstall.
+The default key bindings can be changed in the extension preferences.
 
 ## Options:
 The options menu can be accessed on Mac from LibreOffice -> Preferences -> LibreOffice Writer -> Hoplite Keyboard.  On Linux and Windows it can be accessed from Tools -> Options -> LibreOffice Writer -> Hoplite Keyboard.  On all platforms it can also be accessed from Tools -> Extension Manager; then select the extension and click the Options button.  
@@ -47,6 +47,8 @@ From the options menu you can select the Unicode mode.
 * **Combining-only** mode uses combining diacritics to type decomposed characters.  Few fonts handle combining diacritics well at this point; New Athena Unicode is currently the best.  
 
 There is a detailed discussion of these differences [here](https://apagreekkeys.org/technicalDetails.html).
+
+From the options menu you can also define different key bindings for adding diacritics.
 
 ## Why a LibreOffice extension?  Why not offer this functionality system-wide?
 The Linux, Mac, and Windows operating systems do not provide the keyboard with the information necessary to toggle on/off diacritics.  The Hoplite Keyboard started on [iOS](https://github.com/jeremymarch/HopliteKB-iOS) and [Android](https://github.com/jeremymarch/HopliteKB-Android) where this information *is* provided to the keyboard.  So for Linux, Mac, and Windows the only way to implement this is inside applications.

--- a/src/config.xcs
+++ b/src/config.xcs
@@ -46,7 +46,7 @@
 				oor:name="iotaKey"
 				oor:type="xs:string" />
 			<prop
-				oor:name="diaresisKey"
+				oor:name="diaeresisKey"
 				oor:type="xs:string" />
 			<group oor:name="Defaults">
 				<prop
@@ -105,7 +105,7 @@
 					<value>8</value>
 				</prop>
 				<prop
-					oor:name="diaresisKey"
+					oor:name="diaeresisKey"
 					oor:type="xs:string">
 					<value>9</value>
 				</prop>

--- a/src/config.xcs
+++ b/src/config.xcs
@@ -20,6 +20,34 @@
 			<prop
 				oor:name="UnicodeMode"
 				oor:type="xs:string" />
+			
+			<prop
+			        oor:name="roughKey"
+				oor:type="xs:string" />
+			<prop
+			        oor:name="smoothKey"
+				oor:type="xs:string" />
+			<prop
+			        oor:name="acuteKey"
+				oor:type="xs:string" />
+			<prop
+				oor:name="graveKey"
+				oor:type="xs:string" />
+			<prop
+				oor:name="circumflexKey"
+				oor:type="xs:string" />
+			<prop
+				oor:name="macronKey"
+				oor:type="xs:string" />
+			<prop
+				oor:name="breveKey"
+				oor:type="xs:string" />
+			<prop
+				oor:name="iotaKey"
+				oor:type="xs:string" />
+			<prop
+				oor:name="diaresisKey"
+				oor:type="xs:string" />
 			<group oor:name="Defaults">
 				<prop
 					oor:name="Width"
@@ -35,6 +63,51 @@
 					oor:name="UnicodeMode"
 					oor:type="xs:string">
 					<value>Precomposed</value>
+				</prop>
+				<prop
+					oor:name="roughKey"
+					oor:type="xs:string">
+					<value>1</value>
+				</prop>
+				<prop
+					oor:name="smoothKey"
+					oor:type="xs:string">
+					<value>2</value>
+				</prop>
+				<prop
+					oor:name="acuteKey"
+					oor:type="xs:string">
+					<value>3</value>
+				</prop>
+				<prop
+					oor:name="graveKey"
+					oor:type="xs:string">
+					<value>4</value>
+				</prop>
+				<prop
+					oor:name="circumflexKey"
+					oor:type="xs:string">
+					<value>5</value>
+				</prop>
+				<prop
+					oor:name="macronKey"
+					oor:type="xs:string">
+					<value>6</value>
+				</prop>
+				<prop
+					oor:name="breveKey"
+					oor:type="xs:string">
+					<value>7</value>
+				</prop>
+				<prop
+					oor:name="iotaKey"
+					oor:type="xs:string">
+					<value>8</value>
+				</prop>
+				<prop
+					oor:name="diaresisKey"
+					oor:type="xs:string">
+					<value>9</value>
 				</prop>
 			</group>
 		</group>

--- a/src/dialogs/optionsdialog.xdl
+++ b/src/dialogs/optionsdialog.xdl
@@ -13,50 +13,40 @@
 	dlg:withtitlebar="false">
 <dlg:styles>
   <dlg:style dlg:style-id="0" dlg:font-weight="150"/>
-</dlg:styles>
-<dlg:bulletinboard>
-	<!--
-	<dlg:combobox dlg:id="UnicodeMode" dlg:left="8" dlg:top="63" dlg:width="158" dlg:height="51" dlg:help-text="Unicode Help">
-   <dlg:menupopup>
-    <dlg:menuitem dlg:value="Precomposed"/>
-    <dlg:menuitem dlg:value="Precomposed with PUA"/>
-    <dlg:menuitem dlg:value="Combining-Only"/>
-   </dlg:menupopup>
-  </dlg:combobox>
--->
-
-<dlg:text dlg:id="HKBTitle" dlg:style-id="0" dlg:left="3" dlg:top="3" dlg:width="155" dlg:height="8" dlg:value="Hoplite Polytonic Greek Keyboard Settings"/>
-
-<dlg:titledbox dlg:id="options" dlg:left="3" dlg:top="18" dlg:width="90" dlg:height="50">
-<dlg:title dlg:value="Unicode Mode"/>
-</dlg:titledbox>
-
-<dlg:radiogroup>
-   <dlg:radio dlg:id="PrecomposedOption" dlg:tab-index="1" dlg:left="8" dlg:top="23" dlg:width="232" dlg:height="21" dlg:value="Precomposed" dlg:multiline="true" dlg:valign="center" dlg:help-text="Use precomposed unicode characters where possible.">
-   </dlg:radio>
-   <dlg:radio dlg:id="PrecomposedPUAOption" dlg:tab-index="2" dlg:left="8" dlg:top="35" dlg:width="232" dlg:height="21" dlg:value="Precomposed with PUA" dlg:multiline="true" dlg:valign="center" dlg:help-text="Use precomposed unicode characters including private use area characters where possible.">
-   </dlg:radio>
-   <dlg:radio dlg:id="CombiningOption" dlg:tab-index="3" dlg:left="8" dlg:top="47" dlg:width="232" dlg:height="21" dlg:value="Combining-Only" dlg:multiline="true" dlg:valign="center" dlg:help-text="Use combining characters for diacritics.">
-   </dlg:radio>
-</dlg:radiogroup>
-
-
-<dlg:titledbox dlg:id="InstructionsBox" dlg:left="3" dlg:top="80" dlg:width="90" dlg:height="122">
-<dlg:title dlg:value="Diacritic Keys"/>
-</dlg:titledbox>
-
-<dlg:text dlg:id="rough" dlg:left="8" dlg:top="92" dlg:width="232" dlg:height="8" dlg:value="1 - Rough breathing"/>
-<dlg:text dlg:id="smooth" dlg:left="8" dlg:top="104" dlg:width="232" dlg:height="8" dlg:value="2 - Smooth breathing"/>
-<dlg:text dlg:id="acute" dlg:left="8" dlg:top="116" dlg:width="232" dlg:height="8" dlg:value="3 - Acute"/>
-<dlg:text dlg:id="grave" dlg:left="8" dlg:top="128" dlg:width="232" dlg:height="8" dlg:value="4 - Grave"/>
-<dlg:text dlg:id="circumflex" dlg:left="8" dlg:top="140" dlg:width="232" dlg:height="8" dlg:value="5 - Circumflex"/>
-<dlg:text dlg:id="macron" dlg:left="8" dlg:top="152" dlg:width="232" dlg:height="8" dlg:value="6 - Macron"/>
-<dlg:text dlg:id="breve" dlg:left="8" dlg:top="164" dlg:width="232" dlg:height="8" dlg:value="7 - Breve"/>
-<dlg:text dlg:id="iota" dlg:left="8" dlg:top="176" dlg:width="232" dlg:height="8" dlg:value="8 - Iota subscript"/>
-<dlg:text dlg:id="diaeresis" dlg:left="8" dlg:top="188" dlg:width="232" dlg:height="8" dlg:value="9 - Diaeresis"/>
-<!--<dlg:text dlg:id="underdot" dlg:left="8" dlg:top="104" dlg:width="232" dlg:height="8" dlg:value="0"/>-->
-
- 
-
+ </dlg:styles>
+ <dlg:bulletinboard>
+  <dlg:text dlg:style-id="0" dlg:id="HKBTitle" dlg:tab-index="0" dlg:left="3" dlg:top="3" dlg:width="155" dlg:height="8" dlg:value="Hoplite Polytonic Greek Keyboard Settings"/>
+  <dlg:titledbox dlg:id="options" dlg:tab-index="1" dlg:left="3" dlg:top="18" dlg:width="90" dlg:height="50">
+   <dlg:title dlg:value="Unicode Mode"/>
+  </dlg:titledbox>
+  <dlg:radiogroup>
+   <dlg:radio dlg:id="PrecomposedOption" dlg:tab-index="12" dlg:left="8" dlg:top="23" dlg:width="232" dlg:height="21" dlg:help-text="Use precomposed unicode characters where possible." dlg:value="Precomposed" dlg:valign="center" dlg:multiline="true"/>
+   <dlg:radio dlg:id="PrecomposedPUAOption" dlg:tab-index="13" dlg:left="8" dlg:top="35" dlg:width="232" dlg:height="21" dlg:help-text="Use precomposed unicode characters including private use area characters where possible." dlg:value="Precomposed with PUA" dlg:valign="center" dlg:multiline="true"/>
+   <dlg:radio dlg:id="CombiningOption" dlg:tab-index="14" dlg:left="8" dlg:top="47" dlg:width="232" dlg:height="21" dlg:help-text="Use combining characters for diacritics." dlg:value="Combining-Only" dlg:valign="center" dlg:multiline="true"/>
+  </dlg:radiogroup>
+  <dlg:titledbox dlg:id="InstructionsBox" dlg:tab-index="2" dlg:left="3" dlg:top="80" dlg:width="90" dlg:height="122">
+   <dlg:title dlg:value="Diacritic Keys"/>
+  </dlg:titledbox>
+  <dlg:text dlg:id="rough" dlg:tab-index="3" dlg:left="16" dlg:top="92" dlg:width="224" dlg:height="8" dlg:value="- Rough breathing"/>
+  <dlg:text dlg:id="smooth" dlg:tab-index="4" dlg:left="16" dlg:top="104" dlg:width="224" dlg:height="8" dlg:value="- Smooth breathing"/>
+  <dlg:text dlg:id="acute" dlg:tab-index="5" dlg:left="16" dlg:top="116" dlg:width="224" dlg:height="8" dlg:value="- Acute"/>
+  <dlg:text dlg:id="grave" dlg:tab-index="6" dlg:left="16" dlg:top="128" dlg:width="226" dlg:height="8" dlg:value="- Grave"/>
+  <dlg:text dlg:id="circumflex" dlg:tab-index="7" dlg:left="16" dlg:top="140" dlg:width="232" dlg:height="8" dlg:value="- Circumflex"/>
+  <dlg:text dlg:id="macron" dlg:tab-index="8" dlg:left="16" dlg:top="152" dlg:width="232" dlg:height="8" dlg:value="- Macron"/>
+  <dlg:text dlg:id="breve" dlg:tab-index="9" dlg:left="16" dlg:top="164" dlg:width="232" dlg:height="8" dlg:value="- Breve"/>
+  <dlg:text dlg:id="iota" dlg:tab-index="10" dlg:left="16" dlg:top="176" dlg:width="232" dlg:height="8" dlg:value="- Iota subscript"/>
+  <dlg:text dlg:id="diaeresis" dlg:tab-index="11" dlg:left="16" dlg:top="188" dlg:width="232" dlg:height="8" dlg:value="- Diaeresis"/>
+  <!--<dlg:text dlg:id="underdot" dlg:left="8" dlg:top="104" dlg:width="232" dlg:height="8" dlg:value="0"/>-->
+  
+  <dlg:textfield dlg:id="roughKey" dlg:tab-index="15" dlg:left="8" dlg:top="92" dlg:width="7" dlg:height="8" dlg:maxlength="1" dlg:value="1"/>
+  <dlg:textfield dlg:id="smoothKey" dlg:tab-index="16" dlg:left="8" dlg:top="104" dlg:width="7" dlg:height="8" dlg:maxlength="1" dlg:value="2"/>
+  <dlg:textfield dlg:id="acuteKey" dlg:tab-index="17" dlg:left="8" dlg:top="116" dlg:width="7" dlg:height="8" dlg:maxlength="1" dlg:value="3"/>
+  <dlg:textfield dlg:id="graveKey" dlg:tab-index="18" dlg:left="8" dlg:top="128" dlg:width="7" dlg:height="8" dlg:maxlength="1" dlg:value="4"/>
+  <dlg:textfield dlg:id="circumflexKey" dlg:tab-index="19" dlg:left="8" dlg:top="140" dlg:width="7" dlg:height="8" dlg:maxlength="1" dlg:value="5"/>
+  <dlg:textfield dlg:id="macronKey" dlg:tab-index="20" dlg:left="8" dlg:top="152" dlg:width="7" dlg:height="8" dlg:maxlength="1" dlg:value="6"/>
+  <dlg:textfield dlg:id="breveKey" dlg:tab-index="21" dlg:left="8" dlg:top="164" dlg:width="7" dlg:height="8" dlg:maxlength="1" dlg:value="7"/>
+  <dlg:textfield dlg:id="iotaKey" dlg:tab-index="22" dlg:left="8" dlg:top="176" dlg:width="7" dlg:height="8" dlg:maxlength="1" dlg:value="8"/>
+  <dlg:textfield dlg:id="diaresisKey" dlg:tab-index="23" dlg:left="8" dlg:top="188" dlg:width="7" dlg:height="8" dlg:maxlength="1" dlg:value="9"/>
+  <!--<dlg:textfield dlg:id="debug" dlg:tab-index="24" dlg:left="8" dlg:top="200" dlg:width="230" dlg:height="8" dlg:maxlength="0" dlg:value=""/>-->
 </dlg:bulletinboard>
 </dlg:window>

--- a/src/dialogs/optionsdialog.xdl
+++ b/src/dialogs/optionsdialog.xdl
@@ -46,7 +46,7 @@
   <dlg:textfield dlg:id="macronKey" dlg:tab-index="20" dlg:left="8" dlg:top="152" dlg:width="7" dlg:height="8" dlg:maxlength="1" dlg:value="6"/>
   <dlg:textfield dlg:id="breveKey" dlg:tab-index="21" dlg:left="8" dlg:top="164" dlg:width="7" dlg:height="8" dlg:maxlength="1" dlg:value="7"/>
   <dlg:textfield dlg:id="iotaKey" dlg:tab-index="22" dlg:left="8" dlg:top="176" dlg:width="7" dlg:height="8" dlg:maxlength="1" dlg:value="8"/>
-  <dlg:textfield dlg:id="diaresisKey" dlg:tab-index="23" dlg:left="8" dlg:top="188" dlg:width="7" dlg:height="8" dlg:maxlength="1" dlg:value="9"/>
+  <dlg:textfield dlg:id="diaeresisKey" dlg:tab-index="23" dlg:left="8" dlg:top="188" dlg:width="7" dlg:height="8" dlg:maxlength="1" dlg:value="9"/>
   <!--<dlg:textfield dlg:id="debug" dlg:tab-index="24" dlg:left="8" dlg:top="200" dlg:width="230" dlg:height="8" dlg:maxlength="0" dlg:value=""/>-->
 </dlg:bulletinboard>
 </dlg:window>

--- a/src/py/hoplitekb.py
+++ b/src/py/hoplitekb.py
@@ -143,7 +143,9 @@ transliterateLetters = {
   "F": "Φ",
   "X": "Χ",
   "C": "Ψ",
-  "V": "Ω"
+  "V": "Ω",
+  "?": ";",
+  ";": "·"
 }
 
 def transliterate(s):

--- a/src/py/hoplitekb.py
+++ b/src/py/hoplitekb.py
@@ -370,10 +370,10 @@ def loadDiacriticsKeys():
     ctx = uno.getComponentContext()
     smgr = ctx.getServiceManager()
     readConfig, writeConfig = optionsdialog.createConfigAccessor(ctx, smgr, "/com.philolog.hoplitekb.ExtensionData/Leaves/HKBSettingsNode")
-    defaults = readConfig("Defaults/Width", "Defaults/Height", "Defaults/UnicodeMode", "Defaults/roughKey", "Defaults/smoothKey", "Defaults/acuteKey", "Defaults/graveKey", "Defaults/circumflexKey", "Defaults/macronKey", "Defaults/breveKey", "Defaults/iotaKey", "Defaults/diaresisKey")
+    defaults = readConfig("Defaults/Width", "Defaults/Height", "Defaults/UnicodeMode", "Defaults/roughKey", "Defaults/smoothKey", "Defaults/acuteKey", "Defaults/graveKey", "Defaults/circumflexKey", "Defaults/macronKey", "Defaults/breveKey", "Defaults/iotaKey", "Defaults/diaeresisKey")
     #set current value
-    cfgnames = "Width", "Height", "UnicodeMode", "roughKey", "smoothKey", "acuteKey", "graveKey", "circumflexKey", "macronKey", "breveKey", "iotaKey", "diaresisKey"
-    maxwidth, maxheight, umode, roughKey, smoothKey, acuteKey, graveKey, circumflexKey, macronKey, breveKey, iotaKey, diaresisKey  = readConfig(*cfgnames)
+    cfgnames = "Width", "Height", "UnicodeMode", "roughKey", "smoothKey", "acuteKey", "graveKey", "circumflexKey", "macronKey", "breveKey", "iotaKey", "diaeresisKey"
+    maxwidth, maxheight, umode, roughKey, smoothKey, acuteKey, graveKey, circumflexKey, macronKey, breveKey, iotaKey, diaeresisKey  = readConfig(*cfgnames)
     roughKey = roughKey or defaults[3]
     smoothKey = smoothKey or defaults[4]
     acuteKey = acuteKey or defaults[5]
@@ -382,8 +382,8 @@ def loadDiacriticsKeys():
     macronKey = macronKey or defaults[8]
     breveKey = breveKey or defaults[9]
     iotaKey = iotaKey or defaults[10]
-    diaresisKey = diaresisKey or defaults[11]
-    setDiacriticsKeys([roughKey, smoothKey, acuteKey, graveKey, circumflexKey, macronKey, breveKey, iotaKey, diaresisKey])
+    diaeresisKey = diaeresisKey or defaults[11]
+    setDiacriticsKeys([roughKey, smoothKey, acuteKey, graveKey, circumflexKey, macronKey, breveKey, iotaKey, diaeresisKey])
 
 initializeOptionsOnce()
 loadDiacriticsKeys()

--- a/src/py/hoplitekb.py
+++ b/src/py/hoplitekb.py
@@ -85,6 +85,10 @@ def insertString(ctx, string):
 
 #set default
 vUnicodeMode = hopliteaccent.PRECOMPOSED_MODE 
+diacriticsKeys = []
+def setDiacriticsKeys(val):
+    global diacriticsKeys
+    diacriticsKeys = val
 
 def setUnicodeMode(mode):
     global vUnicodeMode
@@ -190,7 +194,7 @@ class KeyHandler(unohelper.Base, XKeyHandler):
         if oEvent.Modifiers != 0 and oEvent.Modifiers != 1:
             return False
         letter = oEvent.KeyChar.value
-        if letter.isnumeric():
+        if letter in diacriticsKeys:
             self.parent.toggleDiacritic(letter)
             return True
         a = transliterate(letter)
@@ -213,7 +217,6 @@ class ToolbarHandler(unohelper.Base, XServiceInfo,
         self.key_handler = KeyHandler(self, self.ctx)
 
     def toggleDiacritic(self, args):
-
         try:
             if args is None or len(args) < 1:
                 return
@@ -224,23 +227,23 @@ class ToolbarHandler(unohelper.Base, XServiceInfo,
             text = doc.Text
             cursor = text.createTextCursor()
 
-            if args == "3":#"acute":
+            if args == diacriticsKeys[2]: #"3":#"acute":
                 diacriticToAdd = hopliteaccent.kACUTE
-            elif args == "5":#"circumflex":
+            elif args == diacriticsKeys[4]: #"5":#"circumflex":
                 diacriticToAdd = hopliteaccent.kCIRCUMFLEX
-            elif args == "4":#"grave":
+            elif args == diacriticsKeys[3]: #"4":#"grave":
                 diacriticToAdd = hopliteaccent.kGRAVE
-            elif args == "6":#"macron":
+            elif args == diacriticsKeys[5]: #"6":#"macron":
                 diacriticToAdd = hopliteaccent.kMACRON
-            elif args == "1":#"rough":
+            elif args == diacriticsKeys[0]: #"1":#"rough":
                 diacriticToAdd = hopliteaccent.kROUGH_BREATHING
-            elif args == "2":#"smooth":
+            elif args == diacriticsKeys[1]: #"2":#"smooth":
                 diacriticToAdd = hopliteaccent.kSMOOTH_BREATHING
-            elif args == "8":#"iotasub":
+            elif args == diacriticsKeys[7]: #"8":#"iotasub":
                 diacriticToAdd = hopliteaccent.kIOTA_SUBSCRIPT
-            elif args == "9":#"diaeresis":
+            elif args == diacriticsKeys[8]: #"9":#"diaeresis":
                 diacriticToAdd = hopliteaccent.kDIAERESIS
-            elif args == "7":#"breve":
+            elif args == diacriticsKeys[6]: #"7":#"breve":
                 diacriticToAdd = hopliteaccent.kBREVE
             else:
                 return
@@ -343,7 +346,7 @@ g_ImplementationHelper.addImplementation(
     ImplementationName,
     (ServiceName,),)
 
-
+    
 # Settings
 def initializeOptionsOnce():
     ctx = uno.getComponentContext()
@@ -361,11 +364,31 @@ def initializeOptionsOnce():
     else:
         setUnicodeMode(0)
 
+def loadDiacriticsKeys():
+    ctx = uno.getComponentContext()
+    smgr = ctx.getServiceManager()
+    readConfig, writeConfig = optionsdialog.createConfigAccessor(ctx, smgr, "/com.philolog.hoplitekb.ExtensionData/Leaves/HKBSettingsNode")
+    defaults = readConfig("Defaults/Width", "Defaults/Height", "Defaults/UnicodeMode", "Defaults/roughKey", "Defaults/smoothKey", "Defaults/acuteKey", "Defaults/graveKey", "Defaults/circumflexKey", "Defaults/macronKey", "Defaults/breveKey", "Defaults/iotaKey", "Defaults/diaresisKey")
+    #set current value
+    cfgnames = "Width", "Height", "UnicodeMode", "roughKey", "smoothKey", "acuteKey", "graveKey", "circumflexKey", "macronKey", "breveKey", "iotaKey", "diaresisKey"
+    maxwidth, maxheight, umode, roughKey, smoothKey, acuteKey, graveKey, circumflexKey, macronKey, breveKey, iotaKey, diaresisKey  = readConfig(*cfgnames)
+    roughKey = roughKey or defaults[3]
+    smoothKey = smoothKey or defaults[4]
+    acuteKey = acuteKey or defaults[5]
+    graveKey = graveKey or defaults[6]
+    circumflexKey = circumflexKey or defaults[7]
+    macronKey = macronKey or defaults[8]
+    breveKey = breveKey or defaults[9]
+    iotaKey = iotaKey or defaults[10]
+    diaresisKey = diaresisKey or defaults[11]
+    setDiacriticsKeys([roughKey, smoothKey, acuteKey, graveKey, circumflexKey, macronKey, breveKey, iotaKey, diaresisKey])
+
 initializeOptionsOnce()
+loadDiacriticsKeys()
 
 IMPLE_NAME = "com.philolog.hoplitekb.OptionsDialog"
 SERVICE_NAME = "com.philolog.hoplitekb.OptionsDialog"
 def create(ctx, *args):
-    return optionsdialog.create(ctx, *args, imple_name=IMPLE_NAME, service_name=SERVICE_NAME, on_options_changed=setUnicodeMode)
+    return optionsdialog.create(ctx, *args, imple_name=IMPLE_NAME, service_name=SERVICE_NAME, on_options_changed=setUnicodeMode, reload_diacritics_keys = loadDiacriticsKeys)
 
 g_ImplementationHelper.addImplementation(create, IMPLE_NAME, (SERVICE_NAME,),)

--- a/src/py/optionsdialog.py
+++ b/src/py/optionsdialog.py
@@ -9,33 +9,44 @@ from com.sun.star.beans import PropertyValue
 # from com.sun.star.awt.PosSize import POSSIZE  # ピクセル単位でコントロールの座標を指定するときにPosSizeキーの値に使う。
 #import traceback
 
-def create(ctx, *args, imple_name, service_name, on_options_changed):
+def create(ctx, *args, imple_name, service_name, on_options_changed, reload_diacritics_keys):
 	global IMPLE_NAME
 	global SERVICE_NAME
 	IMPLE_NAME = imple_name
 	SERVICE_NAME = service_name
-	dh = DilaogHandler(ctx, on_options_changed, *args)
+	dh = DilaogHandler(ctx, on_options_changed, reload_diacritics_keys, *args)
 	return dh
 
 class DilaogHandler(unohelper.Base, XServiceInfo, XContainerWindowEventHandler):  # UNOコンポーネントにするクラス。
 	METHODNAME = "external_event"  # 変更できない。
-	def __init__(self, ctx, on_options_changed, *args):
+	def __init__(self, ctx, on_options_changed, reload_diacritics_keys, *args):
 		self.ctx = ctx
 		self.on_options_changed = on_options_changed
+		self.reload_diacritics_keys = reload_diacritics_keys
 		self.smgr = ctx.getServiceManager()
 		self.readConfig, self.writeConfig = createConfigAccessor(ctx, self.smgr, "/com.philolog.hoplitekb.ExtensionData/Leaves/HKBSettingsNode")  # config.xcsに定義していあるコンポーネントデータノードへのパス。
-		self.cfgnames = "Width", "Height", "UnicodeMode"
-		self.defaults = self.readConfig("Defaults/Width", "Defaults/Height", "Defaults/UnicodeMode")
+		self.cfgnames = "Width", "Height", "UnicodeMode", "roughKey", "smoothKey", "acuteKey", "graveKey", "circumflexKey", "macronKey", "breveKey", "iotaKey", "diaresisKey"
+		self.defaults = self.readConfig("Defaults/Width", "Defaults/Height", "Defaults/UnicodeMode", "Defaults/roughKey", "Defaults/smoothKey", "Defaults/acuteKey", "Defaults/graveKey", "Defaults/circumflexKey", "Defaults/macronKey", "Defaults/breveKey", "Defaults/iotaKey", "Defaults/diaresisKey")
 
 	# XContainerWindowEventHandler
 	def callHandlerMethod(self, dialog, eventname, methodname):  # ブーリアンを返す必要あり。dialogはUnoControlDialog。 eventnameは文字列initialize, ok, backのいずれか。methodnameは文字列external_event。
 		if methodname==self.METHODNAME:  # Falseのときがありうる?
 			try:
 				if eventname=="initialize":  # オプションダイアログがアクティブになった時
-					maxwidth, maxheight, umode = self.readConfig(*self.cfgnames)  # コンポーネントデータノードの値を取得。取得した値は文字列。
+					maxwidth, maxheight, umode, roughKey, smoothKey, acuteKey, graveKey, circumflexKey, macronKey, breveKey, iotaKey, diaresisKey  = self.readConfig(*self.cfgnames)  # コンポーネントデータノードの値を取得。取得した値は文字列。
 					umode = umode or self.defaults[2]
 					maxwidth = maxwidth or self.defaults[0]
 					maxheight = maxheight or self.defaults[1]
+					roughKey = roughKey or self.defaults[3]
+					smoothKey = smoothKey or self.defaults[4]
+					acuteKey = acuteKey or self.defaults[5]
+					graveKey = graveKey or self.defaults[6]
+					circumflexKey = circumflexKey or self.defaults[7]
+					macronKey = macronKey or self.defaults[8]
+					breveKey = breveKey or self.defaults[9]
+					iotaKey = iotaKey or self.defaults[10]
+					diaresisKey = diaresisKey or self.defaults[11]
+
 					if umode == "PrecomposedPUA":
 						dialog.getControl("PrecomposedOption").getModel().State = False
 						dialog.getControl("PrecomposedPUAOption").getModel().State = True
@@ -48,6 +59,17 @@ class DilaogHandler(unohelper.Base, XServiceInfo, XContainerWindowEventHandler):
 						dialog.getControl("PrecomposedOption").getModel().State = True
 						dialog.getControl("PrecomposedPUAOption").getModel().State = False
 						dialog.getControl("CombiningOption").getModel().State = False
+
+					dialog.getControl("roughKey").getModel().Text = roughKey
+					dialog.getControl("smoothKey").getModel().Text = smoothKey
+					dialog.getControl("acuteKey").getModel().Text = acuteKey
+					dialog.getControl("graveKey").getModel().Text = graveKey
+					dialog.getControl("circumflexKey").getModel().Text = circumflexKey
+					dialog.getControl("macronKey").getModel().Text = macronKey
+					dialog.getControl("breveKey").getModel().Text = breveKey
+					dialog.getControl("iotaKey").getModel().Text = iotaKey
+					dialog.getControl("diaresisKey").getModel().Text = diaresisKey
+					#dialog.getControl("debug").getModel().Text = roughKey + " ciao ciao " + smoothKey + " ciao ciao " + acuteKey + " ciao ciao " + graveKey + " ciao ciao " + circumflexKey + " ciao ciao " + macronKey + " ciao ciao " + breveKey + " ciao ciao " + iotaKey + " ciao ciao " + diaresisKey 
 
 				elif eventname=="ok":  # OKボタンが押された時
 					if dialog.getControl("PrecomposedPUAOption").getModel().State == True:
@@ -59,14 +81,33 @@ class DilaogHandler(unohelper.Base, XServiceInfo, XContainerWindowEventHandler):
 					else:
 						umode = "Precomposed"
 						self.on_options_changed(0) #hopliteaccent.PRECOMPOSED_MODE
+
+					roughKey_new = dialog.getControl("roughKey").getModel().Text
+					smoothKey_new = dialog.getControl("smoothKey").getModel().Text
+					acuteKey_new = dialog.getControl("acuteKey").getModel().Text
+					graveKey_new = dialog.getControl("graveKey").getModel().Text
+					circumflexKey_new = dialog.getControl("circumflexKey").getModel().Text
+					macronKey_new = dialog.getControl("macronKey").getModel().Text
+					breveKey_new = dialog.getControl("breveKey").getModel().Text
+					iotaKey_new = dialog.getControl("iotaKey").getModel().Text
+					diaresisKey_new = dialog.getControl("diaresisKey").getModel().Text
 						
-					self.writeConfig(self.cfgnames, (str("300"), str("300"), str(umode)))  # 取得した値を文字列にしてコンポーネントデータノードに保存。
-					
+					self.writeConfig(self.cfgnames, (str("300"), str("300"), str(umode), str(roughKey_new), str(smoothKey_new), str(acuteKey_new), str(graveKey_new), str(circumflexKey_new), str(macronKey_new), str(breveKey_new), str(iotaKey_new), str(diaresisKey_new)))  # 取得した値を文字列にしてコンポーネントデータノードに保存。
+					self.reload_diacritics_keys()
 				elif eventname=="back":  # 元に戻すボタンが押された時
-					maxwidth, maxheight, umode = self.readConfig(*self.cfgnames)
+					maxwidth, maxheight, umode, roughKey, smoothKey, acuteKey, graveKey, circumflexKey, macronKey, breveKey, iotaKey, diaresisKey  = self.readConfig(*self.cfgnames)
 					umode = umode or self.defaults[2]
 					maxwidth = maxwidth or self.defaults[0]
 					maxheight = maxheight or self.defaults[1]
+					roughKey = roughKey or self.defaults[3]
+					smoothKey = smoothKey or self.defaults[4]
+					acuteKey = acuteKey or self.defaults[5]
+					graveKey = graveKey or self.defaults[6]
+					circumflexKey = circumflexKey or self.defaults[7]
+					macronKey = macronKey or self.defaults[8]
+					breveKey = breveKey or self.defaults[9]
+					iotaKey = iotaKey or self.defaults[10]
+					diaresisKey = diaresisKey or self.defaults[11]
 					if umode == "PrecomposedPUA":
 						dialog.getControl("PrecomposedOption").getModel().State = False
 						dialog.getControl("PrecomposedPUAOption").getModel().State = True
@@ -79,6 +120,16 @@ class DilaogHandler(unohelper.Base, XServiceInfo, XContainerWindowEventHandler):
 						dialog.getControl("PrecomposedOption").getModel().State = True
 						dialog.getControl("PrecomposedPUAOption").getModel().State = False
 						dialog.getControl("CombiningOption").getModel().State = False
+
+					dialog.getControl("roughKey").getModel().Text = roughKey
+					dialog.getControl("smoothKey").getModel().Text = smoothKey
+					dialog.getControl("acuteKey").getModel().Text = acuteKey
+					dialog.getControl("graveKey").getModel().Text = graveKey
+					dialog.getControl("circumflexKey").getModel().Text = circumflexKey
+					dialog.getControl("macronKey").getModel().Text = macronKey
+					dialog.getControl("breveKey").getModel().Text = breveKey
+					dialog.getControl("iotaKey").getModel().Text = iotaKey
+					dialog.getControl("diaresisKey").getModel().Text = diaresisKey
 
 			except:
 				#traceback.print_exc()  # トレースバックはimport pydevd; pydevd.settrace(stdoutToServer=True, stderrToServer=True)でブレークして取得できるようになる。

--- a/src/py/optionsdialog.py
+++ b/src/py/optionsdialog.py
@@ -25,15 +25,15 @@ class DilaogHandler(unohelper.Base, XServiceInfo, XContainerWindowEventHandler):
 		self.reload_diacritics_keys = reload_diacritics_keys
 		self.smgr = ctx.getServiceManager()
 		self.readConfig, self.writeConfig = createConfigAccessor(ctx, self.smgr, "/com.philolog.hoplitekb.ExtensionData/Leaves/HKBSettingsNode")  # config.xcsに定義していあるコンポーネントデータノードへのパス。
-		self.cfgnames = "Width", "Height", "UnicodeMode", "roughKey", "smoothKey", "acuteKey", "graveKey", "circumflexKey", "macronKey", "breveKey", "iotaKey", "diaresisKey"
-		self.defaults = self.readConfig("Defaults/Width", "Defaults/Height", "Defaults/UnicodeMode", "Defaults/roughKey", "Defaults/smoothKey", "Defaults/acuteKey", "Defaults/graveKey", "Defaults/circumflexKey", "Defaults/macronKey", "Defaults/breveKey", "Defaults/iotaKey", "Defaults/diaresisKey")
+		self.cfgnames = "Width", "Height", "UnicodeMode", "roughKey", "smoothKey", "acuteKey", "graveKey", "circumflexKey", "macronKey", "breveKey", "iotaKey", "diaeresisKey"
+		self.defaults = self.readConfig("Defaults/Width", "Defaults/Height", "Defaults/UnicodeMode", "Defaults/roughKey", "Defaults/smoothKey", "Defaults/acuteKey", "Defaults/graveKey", "Defaults/circumflexKey", "Defaults/macronKey", "Defaults/breveKey", "Defaults/iotaKey", "Defaults/diaeresisKey")
 
 	# XContainerWindowEventHandler
 	def callHandlerMethod(self, dialog, eventname, methodname):  # ブーリアンを返す必要あり。dialogはUnoControlDialog。 eventnameは文字列initialize, ok, backのいずれか。methodnameは文字列external_event。
 		if methodname==self.METHODNAME:  # Falseのときがありうる?
 			try:
 				if eventname=="initialize":  # オプションダイアログがアクティブになった時
-					maxwidth, maxheight, umode, roughKey, smoothKey, acuteKey, graveKey, circumflexKey, macronKey, breveKey, iotaKey, diaresisKey  = self.readConfig(*self.cfgnames)  # コンポーネントデータノードの値を取得。取得した値は文字列。
+					maxwidth, maxheight, umode, roughKey, smoothKey, acuteKey, graveKey, circumflexKey, macronKey, breveKey, iotaKey, diaeresisKey  = self.readConfig(*self.cfgnames)  # コンポーネントデータノードの値を取得。取得した値は文字列。
 					umode = umode or self.defaults[2]
 					maxwidth = maxwidth or self.defaults[0]
 					maxheight = maxheight or self.defaults[1]
@@ -45,7 +45,7 @@ class DilaogHandler(unohelper.Base, XServiceInfo, XContainerWindowEventHandler):
 					macronKey = macronKey or self.defaults[8]
 					breveKey = breveKey or self.defaults[9]
 					iotaKey = iotaKey or self.defaults[10]
-					diaresisKey = diaresisKey or self.defaults[11]
+					diaeresisKey = diaeresisKey or self.defaults[11]
 
 					if umode == "PrecomposedPUA":
 						dialog.getControl("PrecomposedOption").getModel().State = False
@@ -68,8 +68,8 @@ class DilaogHandler(unohelper.Base, XServiceInfo, XContainerWindowEventHandler):
 					dialog.getControl("macronKey").getModel().Text = macronKey
 					dialog.getControl("breveKey").getModel().Text = breveKey
 					dialog.getControl("iotaKey").getModel().Text = iotaKey
-					dialog.getControl("diaresisKey").getModel().Text = diaresisKey
-					#dialog.getControl("debug").getModel().Text = roughKey + " ciao ciao " + smoothKey + " ciao ciao " + acuteKey + " ciao ciao " + graveKey + " ciao ciao " + circumflexKey + " ciao ciao " + macronKey + " ciao ciao " + breveKey + " ciao ciao " + iotaKey + " ciao ciao " + diaresisKey 
+					dialog.getControl("diaeresisKey").getModel().Text = diaeresisKey
+					#dialog.getControl("debug").getModel().Text = roughKey + " ciao ciao " + smoothKey + " ciao ciao " + acuteKey + " ciao ciao " + graveKey + " ciao ciao " + circumflexKey + " ciao ciao " + macronKey + " ciao ciao " + breveKey + " ciao ciao " + iotaKey + " ciao ciao " + diaeresisKey 
 
 				elif eventname=="ok":  # OKボタンが押された時
 					if dialog.getControl("PrecomposedPUAOption").getModel().State == True:
@@ -90,12 +90,12 @@ class DilaogHandler(unohelper.Base, XServiceInfo, XContainerWindowEventHandler):
 					macronKey_new = dialog.getControl("macronKey").getModel().Text
 					breveKey_new = dialog.getControl("breveKey").getModel().Text
 					iotaKey_new = dialog.getControl("iotaKey").getModel().Text
-					diaresisKey_new = dialog.getControl("diaresisKey").getModel().Text
+					diaeresisKey_new = dialog.getControl("diaeresisKey").getModel().Text
 						
-					self.writeConfig(self.cfgnames, (str("300"), str("300"), str(umode), str(roughKey_new), str(smoothKey_new), str(acuteKey_new), str(graveKey_new), str(circumflexKey_new), str(macronKey_new), str(breveKey_new), str(iotaKey_new), str(diaresisKey_new)))  # 取得した値を文字列にしてコンポーネントデータノードに保存。
+					self.writeConfig(self.cfgnames, (str("300"), str("300"), str(umode), str(roughKey_new), str(smoothKey_new), str(acuteKey_new), str(graveKey_new), str(circumflexKey_new), str(macronKey_new), str(breveKey_new), str(iotaKey_new), str(diaeresisKey_new)))  # 取得した値を文字列にしてコンポーネントデータノードに保存。
 					self.reload_diacritics_keys()
 				elif eventname=="back":  # 元に戻すボタンが押された時
-					maxwidth, maxheight, umode, roughKey, smoothKey, acuteKey, graveKey, circumflexKey, macronKey, breveKey, iotaKey, diaresisKey  = self.readConfig(*self.cfgnames)
+					maxwidth, maxheight, umode, roughKey, smoothKey, acuteKey, graveKey, circumflexKey, macronKey, breveKey, iotaKey, diaeresisKey  = self.readConfig(*self.cfgnames)
 					umode = umode or self.defaults[2]
 					maxwidth = maxwidth or self.defaults[0]
 					maxheight = maxheight or self.defaults[1]
@@ -107,7 +107,7 @@ class DilaogHandler(unohelper.Base, XServiceInfo, XContainerWindowEventHandler):
 					macronKey = macronKey or self.defaults[8]
 					breveKey = breveKey or self.defaults[9]
 					iotaKey = iotaKey or self.defaults[10]
-					diaresisKey = diaresisKey or self.defaults[11]
+					diaeresisKey = diaeresisKey or self.defaults[11]
 					if umode == "PrecomposedPUA":
 						dialog.getControl("PrecomposedOption").getModel().State = False
 						dialog.getControl("PrecomposedPUAOption").getModel().State = True
@@ -129,7 +129,7 @@ class DilaogHandler(unohelper.Base, XServiceInfo, XContainerWindowEventHandler):
 					dialog.getControl("macronKey").getModel().Text = macronKey
 					dialog.getControl("breveKey").getModel().Text = breveKey
 					dialog.getControl("iotaKey").getModel().Text = iotaKey
-					dialog.getControl("diaresisKey").getModel().Text = diaresisKey
+					dialog.getControl("diaeresisKey").getModel().Text = diaeresisKey
 
 			except:
 				#traceback.print_exc()  # トレースバックはimport pydevd; pydevd.settrace(stdoutToServer=True, stderrToServer=True)でブレークして取得できるようになる。


### PR DESCRIPTION
Hi,

I'm proposing some changes to the code to make diacritics keys configurable. Since I prefer the ibycus way of typing polytonic Greek, and even though I know I could just edit the toogleDiacritic method, I though making the keys configurable could be a nice addition.

Probably my code is a bit redundant but I faced two problem: I'm new to writing Libreoffice extensions and I must confess I didn't find some general introduction to it (the API is instead quite well documented); then I was not able to find a way to easily debug the code: even a typo leads to the extension not being loaded without any indication on where the error is... I was not able, given my limited time, to find out how to log these errors. So I think the code I added could be cleaned up a bit, but it is working and so I'm submitting it.  

I've also updated the readme.

Please let me know.

Best regards,
andrea